### PR TITLE
fix(useSynapse): Run useEffect on every render

### DIFF
--- a/src/useSynapse.js
+++ b/src/useSynapse.js
@@ -14,7 +14,7 @@ export default function useSynapse(selector) {
         setState(nextState);
       }
     });
-  }, []);
+  });
 
   return state;
 }


### PR DESCRIPTION
Discovered in https://github.com/sappira-inc/synaptik/pull/9.

`useEffect` was setup to only be invoked once.  Due to closure and hooks implementation, the subscription callback always pointed to the initial state, leading shallowEqual to run `initial === next` rather than `latest === next`.