### PR TITLE
fix(useSynapse): Update to latest state before subscribing to synapse

### DIFF
--- a/src/useSynapse.js
+++ b/src/useSynapse.js
@@ -7,12 +7,17 @@ export default function useSynapse(selector) {
   const select = () => selector(synapse.stores);
   const [state, setState] = useState(select());
 
+  const updateStateIfChanged = () => {
+    const nextState = select();
+    if (!shallowEqual(nextState, state)) {
+      setState(nextState);
+    }
+  }
+
   useEffect(() => {
+    updateStateIfChanged();
     return synapse.subscribe(() => {
-      const nextState = select();
-      if (!shallowEqual(nextState, state)) {
-        setState(nextState);
-      }
+      updateStateIfChanged()
     });
   });
 


### PR DESCRIPTION
@erikshestopal  found a bug where useEffect would unsubscribe, a store update would occur, and the hook would miss the update before re-subscribing