### PR TITLE
fix(useSynapse): Fix infinite loop when selector returns impure object

### DIFF
--- a/example/components/counter.js
+++ b/example/components/counter.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useSynapse } from '../../src';
+
+export default function Counter() {
+  const state = useSynapse(({ counter }) => ({
+    count: counter.state.count,
+    increment: counter.increment,
+    decrement: counter.decrement,
+  }));
+
+  return (
+    <div>
+      <h2>Counter</h2>
+      {console.info('Rendering Counter')}
+      <button onClick={state.decrement}>-</button>
+      {state.count}
+      <button onClick={state.increment}>+</button>
+    </div>
+  );
+}

--- a/example/components/todo-list.js
+++ b/example/components/todo-list.js
@@ -7,7 +7,6 @@ export default () => {
     todos: todos.state.todos,
     addTodo: todos.addTodo,
     deleteTodo: todos.deleteTodo,
-    randomImpureFunction: () => {}
   }));
 
   const onSubmit = e => {

--- a/example/components/todo-list.js
+++ b/example/components/todo-list.js
@@ -7,6 +7,7 @@ export default () => {
     todos: todos.state.todos,
     addTodo: todos.addTodo,
     deleteTodo: todos.deleteTodo,
+    randomImpureFunction: () => {}
   }));
 
   const onSubmit = e => {

--- a/example/index.js
+++ b/example/index.js
@@ -4,6 +4,7 @@ import { Provider } from '../src';
 import * as stores from './stores';
 import TodoList from './components/todo-list';
 import WeatherForecast from './components/weather-forecast';
+import Counter from './components/counter';
 import logger from '../logger';
 
 const App = () => (
@@ -11,6 +12,7 @@ const App = () => (
     <Fragment>
       <TodoList />
       <WeatherForecast zipCode={94133} />
+      <Counter />
     </Fragment>
   </Provider>
 );

--- a/example/stores/counter.js
+++ b/example/stores/counter.js
@@ -1,0 +1,19 @@
+import { Store } from '../../src';
+
+export default class CounterStore extends Store {
+  state = {
+    count: 0,
+  };
+
+  increment = () => {
+    this.setState(state => ({
+      count: state.count + 1,
+    }));
+  };
+
+  decrement = () => {
+    this.setState(state => ({
+      count: state.count - 1,
+    }));
+  };
+}

--- a/example/stores/index.js
+++ b/example/stores/index.js
@@ -1,4 +1,5 @@
+import counter from './counter';
 import todos from './todos';
 import weather from './weather';
 
-export { todos, weather };
+export { counter, todos, weather };

--- a/src/useSynapse.js
+++ b/src/useSynapse.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext, useState, useLayoutEffect } from 'react';
 import Context from './Context';
 import shallowEqual from './shallow-equal';
 
@@ -7,17 +7,12 @@ export default function useSynapse(selector) {
   const select = () => selector(synapse.stores);
   const [state, setState] = useState(select());
 
-  const updateStateIfChanged = () => {
-    const nextState = select();
-    if (!shallowEqual(nextState, state)) {
-      setState(nextState);
-    }
-  }
-
-  useEffect(() => {
-    updateStateIfChanged();
+  useLayoutEffect(() => {
     return synapse.subscribe(() => {
-      updateStateIfChanged()
+      const nextState = select();
+      if (!shallowEqual(nextState, state)) {
+        setState(nextState);
+      }
     });
   });
 

--- a/src/useSynapse.js
+++ b/src/useSynapse.js
@@ -1,20 +1,48 @@
-import React, { useContext, useState, useLayoutEffect } from 'react';
+import React, { useContext, useState, useEffect, useRef } from 'react';
 import Context from './Context';
 import shallowEqual from './shallow-equal';
 
-export default function useSynapse(selector) {
+export default function useSynapse(selector, dependencies = []) {
   const synapse = useContext(Context);
   const select = () => selector(synapse.stores);
   const [state, setState] = useState(select());
 
-  useLayoutEffect(() => {
-    return synapse.subscribe(() => {
-      const nextState = select();
-      if (!shallowEqual(nextState, state)) {
-        setState(nextState);
+  // By default, our effect only fires on mount and unmount, meaning it won't see the
+  // changes to state, so we use a mutable ref to track the current value
+  const stateRef = useRef(state);
+
+  useEffect(() => {
+    // Helps to avoid running stale listeners after unmount
+    let isUnsubscribed = false;
+
+    const maybeUpdateState = () => {
+      if (isUnsubscribed) {
+        return;
       }
-    });
-  });
+
+      const nextState = select();
+
+      // Checking referential equality grants perf boost if selector is memoized
+      if (
+        nextState === stateRef.current ||
+        shallowEqual(nextState, stateRef.current)
+      ) {
+        return;
+      }
+
+      stateRef.current = nextState;
+      setState(nextState);
+    };
+
+    const unsubscribe = synapse.subscribe(maybeUpdateState);
+
+    maybeUpdateState();
+
+    return () => {
+      unsubscribe();
+      isUnsubscribed = true;
+    };
+  }, dependencies);
 
   return state;
 }


### PR DESCRIPTION
Title mostly sums it. If a selector returned an impure object, nextState would never pass the shallow equal test which would pitch the hook into an infinite rendering cycle.

--- 
**EDIT**

The first solution used `useLayoutEffect`, which _does_ work, however any work inside of useLayout will block the UI thread because it runs synchronously after virtual DOM reconciliation but before browser paint, which could lead to perf issues down the road.

New solution is also preferred because it only runs our subscription effect once, and solves [this issue](https://github.com/heydoctor/synaptik/pull/10) by using a ref to keep track of current state.

Some discussions/implementations from the redux world:
https://github.com/facebookincubator/redux-react-hook/issues/17
https://github.com/ctrlplusb/easy-peasy/blob/master/src/hooks.js