### PR TITLE
RFC: Reduce selected state from array of object paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3446,7 +3446,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -6110,7 +6110,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -10364,8 +10364,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -10638,7 +10637,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -15105,7 +15104,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -15720,7 +15719,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "bump": "standard-version",
-    "format": "prettier --write {src,example}/**/*.js",
+    "format": "prettier --write {src,example,test}/**/*.js",
     "test": "jest",
     "build": "npm-run-all clean rollup",
     "clean": "rimraf dist",
@@ -24,7 +24,8 @@
     "example": "parcel example/index.html"
   },
   "dependencies": {
-    "deep-object-diff": "^1.1.0"
+    "deep-object-diff": "^1.1.0",
+    "lodash.get": "^4.4.2"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/src/useSynapse.js
+++ b/src/useSynapse.js
@@ -1,10 +1,17 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
+import get from 'lodash.get';
 import Context from './Context';
 import shallowEqual from './shallow-equal';
 
 export default function useSynapse(selector, dependencies = []) {
   const synapse = useContext(Context);
-  const select = () => selector(synapse.stores);
+  const select = () =>
+    Array.isArray(selector)
+      ? selector.reduce((state, key) => {
+          state.push(get(synapse.stores, key));
+          return state;
+        }, [])
+      : selector(synapse.stores);
   const [state, setState] = useState(select());
 
   // By default, our effect only fires on mount and unmount, meaning it won't see the


### PR DESCRIPTION
## Problem
Today, `useSynapse` feels repetitive when selecting pieces of state, particularly the object keys which are copied again when destructuring:
```js
const { count, favoriteAvenger } = useSynapse(
  ({ testStore }) => ({
    count: testStore.state.counter,
    favoriteAvenger: testStore.state.favorites.avenger,
  })
);
```

## Proposal
Conforming to the `useState` pattern of destructuring state into an array, we can pass an array of object paths will return an array filled, in the same order, with the values of the path with `stores` as the root:
```js
const [count, favoriteAvenger] = useSynapse([
  'testStore.state.counter',
  'testStore.state.favorites.avenger',
]);
```

## Why
Right now, primarily to write less code. Existing solution uses 170 characters whereas proposed solution uses 117 characters, a 68% reduction to select the same piece of state. I'd also like to setup benchmarking to see how the two solutions compare in more realistic scenarios.

It'd be good to get this out if it does work out as we haven't yet adopted the `useSynapse` hook widely.

## Why not
The new solution adds 5kb to the gzipped bundle:
```
# Before
┌─────────────────────────────────────┐
│   Destination: lib/synaptik.es.js   │
│   Gzipped Size:  1.77 KB            │
└─────────────────────────────────────┘

# After
 ─────────────────────────────────────┐
│   Destination: lib/synaptik.es.js   │
│   Gzipped Size:  1.82 KB            │
└─────────────────────────────────────┘
```

Ugh, sad. Was my assumption but about ~25% slower: https://jsperf.com/selector-func-vs-path-array