### PR TITLE
chore: Fix prop misname on read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Make the vault available to `<Connect>` via context
 - `stores` | `object` | required
   A hash of stores. The key will be used as the accessor name when selecting state. The value is your Store constructor.
 
-- `vault` | `object`
+- `synapse` | `object`
   Alternatively, you can pass in a preinstantiated vault. This is helpful during testing.
 
 - `logger` | `function(oldState: object, newState: object)`


### PR DESCRIPTION
On the readme, the docs show that one can pass an optional prop with
a predefined vault. This prop's real name is synapse, but the readme
calls it vault.