### PR TITLE
fix: Fix setState race condition

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testMatch: ['**/*.spec.(tsx|ts)'],
   transform: { '^.+\\.(ts|tsx|)$': 'babel-jest' },
+  setupFiles: ['<rootDir>/src/test/setup.js'],
 };

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -25,11 +25,10 @@ export class Store<S extends { state: object }, C extends ConstructorMap<C>> {
     this.id = id;
     this.synapse = synapse;
     this.stores = synapse.stores;
-    this.state = {};
   }
 
-  setState(updater: Updater<S['state']>, { log = true } = {}) {
-    return new Promise(resolve => {
+  setState = (updater: Updater<S['state']>, { log = true } = {}) =>
+    new Promise(resolve => {
       const updates: Partial<S['state']> =
         typeof updater === 'function' ? updater(this.state) : updater;
 
@@ -38,21 +37,20 @@ export class Store<S extends { state: object }, C extends ConstructorMap<C>> {
 
       return resolve(this.state);
     });
-  }
 
-  async runAsync<T>({ key, work, log = true }: RunAsync<T, S['state']>) {
+  runAsync = async <T>({ key, work, log = true }: RunAsync<T, S['state']>) => {
     const errorKey = `${key}Error`;
     const storeKey = key || 'loading';
 
-    this.setState({ [storeKey]: true, [errorKey]: null } as S['state'], { log });
+    await this.setState({ [storeKey]: true, [errorKey]: null } as S['state'], { log });
 
     try {
       const res = await work();
-      this.setState({ [storeKey]: false } as S['state'], { log });
+      await this.setState({ [storeKey]: false } as S['state'], { log });
       return res;
     } catch (error) {
-      this.setState({ [storeKey]: false, [errorKey]: error } as S['state'], { log });
+      await this.setState({ [storeKey]: false, [errorKey]: error } as S['state'], { log });
       throw error;
     }
-  }
+  };
 }

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', err => {
+  throw err;
+});


### PR DESCRIPTION
### Summary 
Here's a fun little bug that I discovered in my own code after realizing why the original implementation was written the way it was written 🤦‍♂️

The bug involved these 3 lines in the `Synapse` constructor: 
```ts
const store = new Store(key, this);

this.stores[key] = store;
this.updateState(key, store.state, { log: false });
```

If we have a store that calls `this.setState` from the constructor (as I have discovered when migrating the web-app code to the new TS implementation), then
`this.updateState` will fail because it expects `this.stores[key]` to already be defined _but we only set `this.stores[key]` AFTER the class gets instantiated._ 

**TL;DR**
Added back the `state` class variable to keep track of state independent of class instances. 
