### PR TITLE
fix: Remove optional annotation for store and state fields

### DIFF
--- a/src/createSynaptik.tsx
+++ b/src/createSynaptik.tsx
@@ -14,7 +14,7 @@ type SubscriptionFn = (state: any) => any;
 export type ConstructorMap = Record<string, new (...args: any[]) => any>;
 
 export type StoreMap<T extends ConstructorMap> = {
-  [P in keyof T]?: InstanceType<T[P]>;
+  [P in keyof T]: InstanceType<T[P]>;
 };
 
 export type Synapse<Stores extends ConstructorMap> = {
@@ -40,10 +40,8 @@ export interface SynaptikInstance<Stores extends ConstructorMap> extends Synapse
 }
 
 export function createSynaptik<T extends ConstructorMap>(passedStores: T): SynaptikInstance<T> {
-  const state: {
-    [P in keyof T]?: InstanceType<T[P]>['state'];
-  } = {};
-  const stores: StoreMap<T> = {};
+  const state = {} as { [P in keyof T]: InstanceType<T[P]>['state'] };
+  const stores = {} as StoreMap<T>;
   const subscriptions: Map<number, SubscriptionFn> = new Map();
   let currentSubscriptionId = 0;
 


### PR DESCRIPTION
Noting for posterity - although example works fine, implementing in web-app was causing some issues:
<img width="660" alt="Screen Shot 2020-05-28 at 5 29 25 PM" src="https://user-images.githubusercontent.com/14184138/83208019-72bd2f00-a109-11ea-9770-01758835c3fe.png">
